### PR TITLE
refactor: 오타·네이밍 일괄 정리 (#31)

### DIFF
--- a/Sources/Data/API/Auth/AuthService.swift
+++ b/Sources/Data/API/Auth/AuthService.swift
@@ -14,7 +14,7 @@ public final class AuthService {
     private let provider = MoyaProvider<AuthAPI>(plugins: [NetworkLoggerPlugin()])
     public init() { }
     public func kakaoLogin(token: String) -> AnyPublisher<LoginResponse, Error> {
-        return provider.requestPublisher(.kakaoLogin(request: KakaoLoginRequest(accessToken: token, DeviceType: TokenManager.shared.loadDeviceToken() ?? "시뮬레이터")))
+        return provider.requestPublisher(.kakaoLogin(request: KakaoLoginRequest(accessToken: token, deviceToken: TokenManager.shared.loadDeviceToken() ?? "시뮬레이터")))
             .tryMap { response in
                 guard (200...299).contains(response.statusCode) else {
                     throw MoyaError.statusCode(response)
@@ -27,7 +27,7 @@ public final class AuthService {
             .eraseToAnyPublisher()
     }
     
-    public func kakaoDelte(userId: String) -> AnyPublisher<Void, Error> {
+    public func kakaoDelete(userId: String) -> AnyPublisher<Void, Error> {
         return provider.requestPublisher(.kakaoDelete(request:KakaoDeleteRequest(userId: userId)))
             .tryMap { response in
                 guard (200...299).contains(response.statusCode) else {

--- a/Sources/Data/API/Group/GroupAPI.swift
+++ b/Sources/Data/API/Group/GroupAPI.swift
@@ -10,8 +10,8 @@ import Moya
 
 enum GroupAPI{
     case createGroup(createRequest: CreateGroupRequest)
-    case joinGroup(joinRequest: JoinGorupRequest)
-    case leveGroup(userID: String)
+    case joinGroup(joinRequest: JoinGroupRequest)
+    case leaveGroup(userID: String)
     case infoGroup(userID: String)
     case verify(verifyRequest: VerifyRequest)
 }
@@ -28,7 +28,7 @@ extension GroupAPI: TargetType{
             return "/create"
         case .joinGroup:
             return "/join"
-        case .leveGroup(let userID):
+        case .leaveGroup(let userID):
             return "/leave/\(userID)"
         case .infoGroup(userID: let userID):
             return "info/\(userID)"
@@ -44,7 +44,7 @@ extension GroupAPI: TargetType{
             return .post
         case .joinGroup:
             return .post
-        case .leveGroup(_):
+        case .leaveGroup(_):
             return .delete
         case .infoGroup(_):
             return .get
@@ -59,7 +59,7 @@ extension GroupAPI: TargetType{
             return .requestJSONEncodable(request)
         case .joinGroup(let request):
             return .requestJSONEncodable(request)
-        case .leveGroup(_):
+        case .leaveGroup(_):
             return .requestPlain
         case .infoGroup(_):
             return .requestPlain

--- a/Sources/Data/API/Group/GroupService.swift
+++ b/Sources/Data/API/Group/GroupService.swift
@@ -10,9 +10,9 @@ import Moya
 
 public protocol GroupServiceType {
     func createGroup(groupRequest: CreateGroupRequest, completion: @escaping (Result<CreateGroupResponse, APIError>) -> Void)
-    func joinGroup(joinGroup: JoinGorupRequest, completion: @escaping (Result<Void, APIError>) -> Void)
+    func joinGroup(joinGroup: JoinGroupRequest, completion: @escaping (Result<Void, APIError>) -> Void)
     func leaveGroup(userID: String, completion: @escaping (Result<Void, APIError>) -> Void)
-    func infoGroup(userID: String, completion: @escaping (Result<InfoGroupRespose, APIError>) -> Void)
+    func infoGroup(userID: String, completion: @escaping (Result<InfoGroupResponse, APIError>) -> Void)
     func verifyGroupCode(groupCode: VerifyRequest, completion: @escaping(Result<VerifyResponse,APIError>) -> Void)
 }
 
@@ -30,7 +30,7 @@ public class GroupService: GroupServiceType {
     
     // MARK: - Join Group (Void 응답)
     public func joinGroup(
-        joinGroup: JoinGorupRequest,
+        joinGroup: JoinGroupRequest,
         completion: @escaping (Result<Void, APIError>) -> Void
     ) {
         provider.requestWithValidation(
@@ -56,7 +56,7 @@ public class GroupService: GroupServiceType {
         completion: @escaping (Result<Void, APIError>) -> Void
     ) {
         provider.requestWithValidation(
-            .leveGroup(userID: userID),
+            .leaveGroup(userID: userID),
             completion: completion
         )
     }
@@ -64,7 +64,7 @@ public class GroupService: GroupServiceType {
     // MARK: - Info Group (데이터 응답)
     public func infoGroup(
         userID: String,
-        completion: @escaping (Result<InfoGroupRespose, APIError>) -> Void
+        completion: @escaping (Result<InfoGroupResponse, APIError>) -> Void
     ) {
         provider.requestWithValidation(
             .infoGroup(userID: userID),

--- a/Sources/Data/DTO/Request/AuthRequest.swift
+++ b/Sources/Data/DTO/Request/AuthRequest.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 public struct KakaoLoginRequest: Codable {
-    public let accessToken: String, DeviceType: String
+    public let accessToken: String, deviceToken: String
     
     public enum CodingKeys: String, CodingKey {
         case accessToken =  "access_token"
-        case DeviceType = "device_token"
+        case deviceToken = "device_token"
     }
 }
 

--- a/Sources/Data/DTO/Request/CreateGroupRequest.swift
+++ b/Sources/Data/DTO/Request/CreateGroupRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// MARK: - CreateGorupRequest
+// MARK: - CreateGroupRequest
 public struct CreateGroupRequest: Codable {
     public let userID, groupName,nickname: String
 

--- a/Sources/Data/DTO/Request/JoinGroupRequest.swift
+++ b/Sources/Data/DTO/Request/JoinGroupRequest.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-// MARK: - GroupGorupRequest
-public struct JoinGorupRequest: Codable {
+// MARK: - GroupGroupRequest
+public struct JoinGroupRequest: Codable {
     public let joinCode, userID, nickname: String
     
     public init(joinCode: String, userID: String, nickname: String) {

--- a/Sources/Data/DTO/Response/CreateGroupResponse.swift
+++ b/Sources/Data/DTO/Response/CreateGroupResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// MARK: - CreateGorupResponse
+// MARK: - CreateGroupResponse
 public struct CreateGroupResponse: Codable {
     public let groupID, joinCode, creatorID: String
     public let createdAt: String

--- a/Sources/Data/DTO/Response/InfoGroupResponse.swift
+++ b/Sources/Data/DTO/Response/InfoGroupResponse.swift
@@ -1,5 +1,5 @@
 //
-//  InfoGroupRespose.swift
+//  InfoGroupResponse.swift
 //  WatchOut
 //
 //  Created by 어재선 on 9/18/25.
@@ -7,8 +7,8 @@
 
 import Foundation
 
-// MARK: - InfoGroupRespose
-public struct InfoGroupRespose: Codable {
+// MARK: - InfoGroupResponse
+public struct InfoGroupResponse: Codable {
     public let groupID, groupName, joinCode, creatorID: String
     public let memberCount: Int
     public var members: [Member]

--- a/Sources/Data/DTO/Response/JoinGroupResponse.swift
+++ b/Sources/Data/DTO/Response/JoinGroupResponse.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-// MARK: - GroupGorupResponse
-struct JoinGorupResponse: Codable {
+// MARK: - GroupGroupResponse
+struct JoinGroupResponse: Codable {
     let groupID, creatorName, joinedAt: String
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/Data/DTO/Response/LoginResponse.swift
+++ b/Sources/Data/DTO/Response/LoginResponse.swift
@@ -1,5 +1,5 @@
 //
-//  LoginRespose.swift
+//  LoginResponse.swift
 //  WatchOut
 //
 //  Created by 어재선 on 9/18/25.

--- a/Sources/Data/Manager/TokenManager.swift
+++ b/Sources/Data/Manager/TokenManager.swift
@@ -1,5 +1,5 @@
 //
-//  TokenManger.swift
+//  TokenManager.swift
 //  WatchOut
 //
 //  Created by 어재선 on 9/18/25.

--- a/Sources/Data/MoyaProvider+Extension.swift
+++ b/Sources/Data/MoyaProvider+Extension.swift
@@ -1,5 +1,5 @@
 //
-//  MoyaProvider+Extention.swift
+//  MoyaProvider+Extension.swift
 //  WatchOut
 //
 //  Created by 어재선 on 10/27/25.

--- a/Sources/FeatureGroup/CreateGroupView.swift
+++ b/Sources/FeatureGroup/CreateGroupView.swift
@@ -123,7 +123,7 @@ public struct CreateGroupView: View {
 
                         
                         Button {
-                            groupViewModel.CreateGorupAction()
+                            groupViewModel.CreateGroupAction()
                         } label: {
                             HStack {
                                 Spacer()

--- a/Sources/FeatureGroup/GroupViewModel.swift
+++ b/Sources/FeatureGroup/GroupViewModel.swift
@@ -40,14 +40,14 @@ class GroupViewModel: ObservableObject {
         joinedAt: "",
         notificationEnabled: true
     )
-    @Published var infoGroupRespose: InfoGroupRespose?
+    @Published var infoGroupResponse: InfoGroupResponse?
     @Published var isCreate: Bool {
         didSet {
             SharedUserDefaults.isCreateGroup = isCreate
         }
     }
     @Published var isLeave: Bool = false
-    @Published private var createGroupRespose: CreateGroupResponse?
+    @Published private var createGroupResponse: CreateGroupResponse?
     @Published var isJoinGroup: Bool = false
     
     @Published var showError = false
@@ -162,16 +162,16 @@ extension GroupViewModel {
     
     
     func countMembers() -> Int {
-        guard let infoGroup = self.infoGroupRespose else { return 0}
+        guard let infoGroup = self.infoGroupResponse else { return 0}
         
         return infoGroup.memberCount
     }
     
-    func CreateGorupAction() {
-        CreateGorup()
+    func CreateGroupAction() {
+        CreateGroup()
     }
     
-    func LeaveGorupAction() {
+    func LeaveGroupAction() {
         leaveGroup()
     }
     
@@ -187,7 +187,7 @@ extension GroupViewModel {
         infoGroup { [weak self] in
             guard let self = self else { return }
             
-            if let member = self.infoGroupRespose?.members.first {
+            if let member = self.infoGroupResponse?.members.first {
                 self.selectMembers = member
             }
             
@@ -204,7 +204,7 @@ extension GroupViewModel {
     }
     private func joinGroup() {
         self.service.joinGroup(
-            joinGroup: JoinGorupRequest(
+            joinGroup: JoinGroupRequest(
                 joinCode: groupCode,
                 userID: user.userId,
                 nickname: userName.isEmpty ? user.nickname : userName
@@ -246,7 +246,7 @@ extension GroupViewModel {
     }
     
     private func infoGroup(completion: (() -> Void)? = nil) {
-        if infoGroupRespose == nil {
+        if infoGroupResponse == nil {
             self.isLoading = true
         }
         self.service.infoGroup(userID: user.userId) { [weak self] result in
@@ -257,13 +257,13 @@ extension GroupViewModel {
                 self.isLoading = false
                 switch result {
                 case .success(let response):
-                    self.infoGroupRespose = response
+                    self.infoGroupResponse = response
                     
-                    self.infoGroupRespose?.members = self.infoGroupRespose?.members.sorted {
+                    self.infoGroupResponse?.members = self.infoGroupResponse?.members.sorted {
                         ($0.userID == self.user.userId) && ($1.userID != self.user.userId)
                     } ?? []
                     completion?()
-                    print("✅ infoGroup 성공: \(String(describing: self.infoGroupRespose?.members))")
+                    print("✅ infoGroup 성공: \(String(describing: self.infoGroupResponse?.members))")
                     
                 case .failure(let error):
                     SharedUserDefaults.isCreateGroup = false
@@ -296,7 +296,7 @@ extension GroupViewModel {
         }
     }
     
-    private func CreateGorup() {
+    private func CreateGroup() {
         guard !groupName.isEmpty else {
             
             return
@@ -316,7 +316,7 @@ extension GroupViewModel {
                 case .success(let response):
                     print("✅ CreateGroup 성공")
                     self.isCreate = true
-                    self.createGroupRespose = response
+                    self.createGroupResponse = response
                     self.groupName = ""
                     
                 case .failure(let error):

--- a/Sources/FeatureGroup/ManagementGroupView.swift
+++ b/Sources/FeatureGroup/ManagementGroupView.swift
@@ -32,7 +32,7 @@ public struct ManagementGroupView: View {
                 HStack(alignment: .bottom) {
                     VStack {
                         HStack {
-                            Text(groupViewModel.infoGroupRespose?.groupName ?? "")
+                            Text(groupViewModel.infoGroupResponse?.groupName ?? "")
                                 .font(.gHeadline01)
                             Text("총 \( groupViewModel.countMembers())명")
                         }
@@ -47,12 +47,12 @@ public struct ManagementGroupView: View {
                         .font(.pSubtitle03)
                         .foregroundStyle(Color.gray300)
                     Spacer()
-                    Text(groupViewModel.infoGroupRespose?.joinCode ?? "")
+                    Text(groupViewModel.infoGroupResponse?.joinCode ?? "")
                         .font(.pBody01)
                         .underline()
                     Button {
                         
-                        UIPasteboard.general.strings = [groupViewModel.infoGroupRespose?.joinCode ?? ""]
+                        UIPasteboard.general.strings = [groupViewModel.infoGroupResponse?.joinCode ?? ""]
                         isToastShown.toggle()
                     } label: {
                         Image("CopyIcon")
@@ -70,7 +70,7 @@ public struct ManagementGroupView: View {
                     HStack {
                         Spacer()
                             .frame(width: 20)
-                        ForEach(groupViewModel.infoGroupRespose?.members ?? [], id: \.userID) { member in
+                        ForEach(groupViewModel.infoGroupResponse?.members ?? [], id: \.userID) { member in
                             ProfileView(groupViewModel: groupViewModel, member: member)
                                 .onTapGesture {
                                     groupViewModel.selectMembers = member
@@ -149,8 +149,8 @@ private struct UserInfoView: View {
                 
                 Spacer()
                     .frame(height: 50)
-                if(groupViewModel.infoGroupRespose?.creatorID == groupViewModel.user.userId){
-                    if (groupViewModel.infoGroupRespose?.creatorID != groupViewModel.selectMembers.userID) {
+                if(groupViewModel.infoGroupResponse?.creatorID == groupViewModel.user.userId){
+                    if (groupViewModel.infoGroupResponse?.creatorID != groupViewModel.selectMembers.userID) {
                         Text("강퇴하기")
                             .underline()
                             .font(.pBody02)
@@ -176,7 +176,7 @@ private struct UserInfoView: View {
                     .alert(isPresented: $groupViewModel.isLeave) {
                         Alert(title: Text("그룹을 해체하시겠습니까?"), message: Text("그룹을 해체하면 모든 그룹원이 강퇴됩니다."), primaryButton: .destructive(Text("나가기"), action: {
                             DispatchQueue.main.async {
-                                groupViewModel.LeaveGorupAction()
+                                groupViewModel.LeaveGroupAction()
                                 _ = pathModel.paths.popLast()
                                 groupViewModel.isCreate = false
                             }
@@ -194,7 +194,7 @@ private struct UserInfoView: View {
                         .alert(isPresented: $groupViewModel.isLeave) {
                             Alert(title: Text("그룹을 나가시겠습니까?"), primaryButton: .destructive(Text("나가기"), action: {
                                 DispatchQueue.main.async {
-                                    groupViewModel.LeaveGorupAction()
+                                    groupViewModel.LeaveGroupAction()
                                     _ = pathModel.paths.popLast()
                                     groupViewModel.isCreate = false
                                 }

--- a/Sources/FeatureMain/MainTabViewModel.swift
+++ b/Sources/FeatureMain/MainTabViewModel.swift
@@ -38,7 +38,7 @@ class MainTabViewModel: ObservableObject {
     
     private func requestDeleteServer(with userId: String, completion: @escaping (_ success: Bool) -> Void) {
         isLoading = true
-        authService.kakaoDelte(userId: userId)
+        authService.kakaoDelete(userId: userId)
             .sink { [weak self]
                 result in
                 guard let self = self else { return }

--- a/Sources/Shared/Component/CustomNavigationBar.swift
+++ b/Sources/Shared/Component/CustomNavigationBar.swift
@@ -1,5 +1,5 @@
 //
-//  CustomNavigaitonBar.swift
+//  CustomNavigationBar.swift
 //  WatchOut
 //
 //  Created by 어재선 on 9/6/25.


### PR DESCRIPTION
## 작업 내용
코드 전반의 타입/메서드/파일명 오타를 정상 철자로 통일했습니다. **동작 변경 없음** (순수 식별자/파일명 정리).

| 오타 | 수정 |
|---|---|
| `Respose` | `Response` |
| `Gorup` | `Group` |
| `kakaoDelte` | `kakaoDelete` |
| `leveGroup` | `leaveGroup` |
| `DeviceType` | `deviceToken` (서버 키 `device_token` 유지) |

파일명 rename: `TokenManger`→`TokenManager`, `MoyaProvider+Extention`→`+Extension`, `CustomNavigaitonBar`→`CustomNavigationBar`, `LoginRespose`→`LoginResponse`, `InfoGroupRespose`→`InfoGroupResponse`

## 범위 밖 (별도 단계)
- 메서드 PascalCase→lowerCamelCase (`CreateGroupAction` 등)
- DTO `userID` vs Entity `userId` 표기 통일
- ⚠️ `dotlottie-ios` 의존성 해석 오류(기존 문제) — 빌드 검증 불가, 별도 대응 필요

## base
#29(모듈 의존성 정리) 위에 쌓이는 작업이라 해당 브랜치를 base로 설정.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)