### PR TITLE
feat: #38 - 영어 대문자 롱프레스, 백스페이스 연속 삭제, 스페이스 커서 이동

### DIFF
--- a/WatchOutkeyboard/View/KeyboardView.swift
+++ b/WatchOutkeyboard/View/KeyboardView.swift
@@ -20,11 +20,15 @@ struct KeyboardView: View {
     @State var count = 0
     @State var oldText : String = ""
 
-    // 롱프레스 쌍자음 팝업 상태
+    // 롱프레스 상태 (쌍자음/대문자 팝업, 백스페이스 반복, 스페이스 커서 모드)
     @State private var keyFrames: [KeyType: CGRect] = [:]
     @State private var popupKey: KeyType?
     @State private var pressedKeys: Set<KeyType> = []
     @State private var longPressTasks: [KeyType: Task<Void, Never>] = [:]
+    @State private var didRepeatDelete = false
+    @State private var spaceCursorMode = false
+    @State private var spaceCursorSteps = 0
+    @State private var spaceTranslation: CGFloat = 0
     
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -154,20 +158,25 @@ struct KeyboardView: View {
         .cornerRadius(8)
     }
     
-    // MARK: - Long Press (쌍자음)
+    // MARK: - Long Press (쌍자음/대문자 팝업, 백스페이스 반복, 스페이스 커서)
     private func keyGesture(for key: KeyType) -> some Gesture {
         DragGesture(minimumDistance: 0)
-            .onChanged { _ in
-                guard !pressedKeys.contains(key) else { return }
-                pressedKeys.insert(key)
+            .onChanged { value in
+                if !pressedKeys.contains(key) {
+                    pressedKeys.insert(key)
+                    startLongPress(for: key)
+                }
 
-                guard controller.variant(for: key) != nil else { return }
-                longPressTasks[key]?.cancel()
-                longPressTasks[key] = Task { @MainActor in
-                    try? await Task.sleep(for: .milliseconds(400))
-                    guard !Task.isCancelled, pressedKeys.contains(key) else { return }
-                    popupKey = key
-                    Haptic.impact(style: .medium)
+                if key == .space {
+                    spaceTranslation = value.translation.width
+                    if spaceCursorMode {
+                        let steps = Int(spaceTranslation / 8)
+                        let delta = steps - spaceCursorSteps
+                        if delta != 0 {
+                            spaceCursorSteps = steps
+                            controller.moveCursor(by: delta)
+                        }
+                    }
                 }
             }
             .onEnded { _ in
@@ -175,16 +184,60 @@ struct KeyboardView: View {
                 longPressTasks[key]?.cancel()
                 longPressTasks[key] = nil
 
-                if popupKey == key {
+                switch key {
+                case .space where spaceCursorMode:
+                    spaceCursorMode = false
+                    spaceCursorSteps = 0
+                case .backspace where didRepeatDelete:
+                    didRepeatDelete = false
+                case _ where popupKey == key:
                     popupKey = nil
                     controller.handleLongPress(key)
-                } else {
+                default:
                     controller.handleKeyPress(key)
                 }
 
                 let currentText = controller.textDocumentProxy.documentContextBeforeInput ?? ""
                 webSocketService.checkFraudMessage(currentText)
             }
+    }
+
+    private func startLongPress(for key: KeyType) {
+        longPressTasks[key]?.cancel()
+
+        switch key {
+        case .character where controller.variant(for: key) != nil:
+            longPressTasks[key] = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(400))
+                guard !Task.isCancelled, pressedKeys.contains(key) else { return }
+                popupKey = key
+                Haptic.impact(style: .medium)
+            }
+
+        case .backspace:
+            longPressTasks[key] = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(400))
+                guard !Task.isCancelled, pressedKeys.contains(key) else { return }
+                didRepeatDelete = true
+                while !Task.isCancelled, pressedKeys.contains(key) {
+                    controller.handleKeyPress(.backspace)
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+            }
+
+        case .space:
+            longPressTasks[key] = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(400))
+                guard !Task.isCancelled, pressedKeys.contains(key) else { return }
+                controller.beginCursorMode()
+                spaceCursorSteps = Int(spaceTranslation / 8)
+                spaceCursorMode = true
+                Haptic.impact(style: .medium)
+            }
+
+        default:
+            break
+        }
     }
 
     @ViewBuilder
@@ -214,6 +267,9 @@ struct KeyboardView: View {
         pressedKeys.removeAll()
         longPressTasks.values.forEach { $0.cancel() }
         longPressTasks.removeAll()
+        didRepeatDelete = false
+        spaceCursorMode = false
+        spaceCursorSteps = 0
     }
 
     // MARK: - keyView

--- a/WatchOutkeyboard/View/KeyboardViewController.swift
+++ b/WatchOutkeyboard/View/KeyboardViewController.swift
@@ -89,8 +89,16 @@ class KeyboardViewController: UIInputViewController, ObservableObject {
     ]
 
     func variant(for key: KeyType) -> Character? {
-        guard keyboardMode == .korean, case .character(let char) = key else { return nil }
-        return Self.shiftedJamo[char]
+        guard case .character(let char) = key else { return nil }
+        switch keyboardMode {
+        case .korean:
+            return Self.shiftedJamo[char]
+        case .english:
+            guard char.isLowercase else { return nil }
+            return Character(char.uppercased())
+        default:
+            return nil
+        }
     }
 
     func handleLongPress(_ key: KeyType) {
@@ -99,6 +107,15 @@ class KeyboardViewController: UIInputViewController, ObservableObject {
             return
         }
         handleCharacterKey(shifted)
+    }
+
+    // MARK: - Cursor Movement (스페이스 트랙패드)
+    func beginCursorMode() {
+        finalizeHangulInput()
+    }
+
+    func moveCursor(by offset: Int) {
+        textDocumentProxy.adjustTextPosition(byCharacterOffset: offset)
     }
 
     // MARK: - Key Handling


### PR DESCRIPTION
## 개요

Closes #38

#34의 롱프레스 인프라(DragGesture + 키별 타이머)를 확장해 세 가지 기능을 추가합니다.

## 변경 내용

### 1. 영어 대문자 롱프레스
- `variant(for:)`를 모드별 분기로 확장 — 영문 모드에서 소문자 키 홀드 시 대문자 팝업 표시 후 입력 (쌍자음과 동일 UX)

### 2. 백스페이스 연속 삭제
- 0.4초 홀드 후 0.1초 간격으로 반복 삭제
- `didRepeatDelete` 플래그로 release 시 추가 1회 삭제 방지
- 한글 모드에서는 기존 `HangulEngine.deleteBackward()` 경로 그대로 — 자모 분해 삭제 동작 유지

### 3. 스페이스바 커서 이동 (트랙패드 모드)
- 0.4초 홀드 시 햅틱과 함께 커서 모드 진입
- 진입 시 `finalizeHangulInput()`으로 조합 중 글자 확정 (커서 이동 꼬임 방지)
- 좌우 드래그 8pt당 `textDocumentProxy.adjustTextPosition` 1칸
- 커서 모드로 끝난 터치는 스페이스 미입력

## 검증

- Xcode 27.0 베타 (27A5194q): BUILD SUCCEEDED ✅
- Xcode 26.5 (17F42): BUILD SUCCEEDED ✅
- 실기기 체크리스트:
  - [ ] 영문 모드 `a` 홀드 → `A` 팝업·입력, 짧은 탭 → `a`
  - [ ] 백스페이스 홀드 → 연속 삭제, 짧은 탭 → 1글자
  - [ ] 한글 조합 중 백스페이스 홀드 → 자모 단위 분해 후 글자 삭제
  - [ ] 스페이스 홀드 후 드래그 → 커서 이동, 손 떼도 스페이스 미입력
  - [ ] 스페이스 짧은 탭 → 공백 입력 정상

## 비고

스택: dev ← #31 ← #34(PR #35) ← #36(PR #37) ← 이 PR. 커서 모드 시각 피드백(키 글자 숨김)과 백스페이스 가속 삭제는 후속 과제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)