### PR TITLE
feat: #54 - 키보드 키 눌림 애니메이션

### DIFF
--- a/WatchOutkeyboard/View/KeyboardView.swift
+++ b/WatchOutkeyboard/View/KeyboardView.swift
@@ -41,6 +41,9 @@ struct KeyboardView: View {
                         HStack(spacing: 7) {
                             ForEach(row, id: \.self) { key in
                                 keyView(for: key)
+                                    .scaleEffect(pressedKeys.contains(key) ? 0.9 : 1)
+                                    .opacity(pressedKeys.contains(key) ? 0.6 : 1)
+                                    .animation(.easeOut(duration: 0.1), value: pressedKeys.contains(key))
                                     .contentShape(Rectangle())
                                     .background(GeometryReader { geo in
                                         Color.clear.preference(


### PR DESCRIPTION
## 개요

Closes #54

키를 누르는 동안 눌림 피드백(0.9배 축소 + 60% 불투명도)을 표시하고, 떼면 0.1초 easeOut으로 원복합니다. #34에서 Button → DragGesture로 바꾸며 사라졌던 기본 눌림 하이라이트의 복원입니다.

## 구현

- 기존 `pressedKeys` Set(터치 다운에 insert, 업에 remove)을 그대로 시각 효과 드라이버로 사용 — 상태 추가 없음, 3줄 수정
- 롱프레스 팝업/연속 삭제/커서 모드와 자연스럽게 공존 (누르는 동안 계속 눌림 표시)

## 검증

- Xcode 27.0 베타 / 26.5 키보드 스킴 BUILD SUCCEEDED ✅
- 실기기 확인: 짧은 탭/롱프레스 시 키가 눌렸다 복원되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)