### PR TITLE
feat: #56 - 키 입력 시 가벼운 햅틱 피드백

### DIFF
--- a/WatchOutkeyboard/View/KeyboardView.swift
+++ b/WatchOutkeyboard/View/KeyboardView.swift
@@ -126,6 +126,7 @@ struct KeyboardView: View {
             .onChanged { value in
                 if !pressedKeys.contains(key) {
                     pressedKeys.insert(key)
+                    Haptic.impact(style: .soft)
                     startLongPress(for: key)
                 }
 


### PR DESCRIPTION
## 개요

Closes #56

키를 누르는 순간(터치 다운) 가장 약한 강도의 햅틱(`UIImpactFeedbackGenerator` `.soft`)이 1회 발생합니다. 눌림 애니메이션(#54)과 합쳐져 iOS 기본 키보드와 유사한 타건감을 만듭니다.

## 구현

- `keyGesture`의 터치 다운 분기(pressedKeys.insert 직후)에 `Haptic.impact(style: .soft)` 1줄
- 키당 1회만 — 백스페이스 연속 삭제 반복이나 스페이스 커서 드래그 중에는 발생하지 않음
- 롱프레스 팝업 진입의 `.medium` 햅틱과 강도로 구분됨

## 검증

- Xcode 27.0 베타 / 26.5 키보드 스킴 BUILD SUCCEEDED ✅
- 실기기 확인: 타건감 강도가 적당한지 (.soft → 더 강하게 원하면 .light로 한 단계 올릴 수 있음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)