### PR TITLE
fix: #58 - 키 그림자 제거 및 눌림 효과 즉각 반응

### DIFF
--- a/WatchOutkeyboard/View/KeyboardView.swift
+++ b/WatchOutkeyboard/View/KeyboardView.swift
@@ -41,9 +41,11 @@ struct KeyboardView: View {
                         HStack(spacing: 7) {
                             ForEach(row, id: \.self) { key in
                                 keyView(for: key)
-                                    .scaleEffect(pressedKeys.contains(key) ? 0.9 : 1)
-                                    .opacity(pressedKeys.contains(key) ? 0.6 : 1)
-                                    .animation(.easeOut(duration: 0.1), value: pressedKeys.contains(key))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 8.5)
+                                            .fill(.black.opacity(pressedKeys.contains(key) ? 0.12 : 0))
+                                    )
+                                    .animation(pressedKeys.contains(key) ? nil : .easeOut(duration: 0.15), value: pressedKeys.contains(key))
                                     .contentShape(Rectangle())
                                     .background(GeometryReader { geo in
                                         Color.clear.preference(
@@ -280,7 +282,6 @@ struct KeyboardView: View {
         .background(keyBackgroundColor(for: key))
         .foregroundColor(.primary)
         .cornerRadius(8.5)
-        .shadow(color: .black.opacity(0.35), radius: 0.5, x: 0, y: 1)
     }
     // MARK: - keyBackgroundColor
     private func keyBackgroundColor(for key: KeyType) -> Color {


### PR DESCRIPTION
## 개요

Closes #58

## 변경

1. **키 그림자 제거** — 키마다 깔려 있던 `.shadow` 삭제로 평면적인 깔끔한 키. 쌍자음/대문자 팝업 말풍선의 그림자는 떠 있다는 입체감을 위해 유지
2. **눌림 효과 개선** — 딜레이 체감 해결:
   - 기존: scale 0.9 + opacity 0.6에 0.1초 애니메이션이 **누를 때도** 적용 → 손가락보다 늦게 반응하는 느낌
   - 변경: 누르는 순간 **애니메이션 없이 즉시** 어두운 오버레이(black 12%), 뗄 때만 0.15초 easeOut으로 페이드 복원 — iOS 기본 키보드와 같은 패턴

## 검증

- Xcode 27.0 베타 / 26.5 키보드 스킴 BUILD SUCCEEDED ✅
- 실기기 확인: 누르는 순간 지연 없이 어두워지는지, 어둡기(12%)가 적당한지

🤖 Generated with [Claude Code](https://claude.com/claude-code)