### PR TITLE
fix: #60 - 상세 설정 경고 아이콘 색상 미반영 수정

### DIFF
--- a/Sources/Features/Setting/Setting/SettingView.swift
+++ b/Sources/Features/Setting/Setting/SettingView.swift
@@ -124,7 +124,7 @@ private struct SheetView: View {
                 LazyVGrid(columns:columns,alignment: .leading) {
                     ForEach(Range(1...7), id: \.self) { index in
                         Circle()
-                            .foregroundStyle(Color(status == .danger ? "Risk1Color\(index)" :"RiskColor\(index)" ))
+                            .foregroundStyle(status == .danger ? Color.risk1Color("\(index)") : Color.riskColor("\(index)"))
                             .frame(width: 24,height: 24)
                             .padding(4)
                             .overlay{
@@ -145,7 +145,7 @@ private struct SheetView: View {
             ZStack {
                 Image("KeyboardImage")
                 Image("KeyboardStatusImage")
-                    .foregroundStyle(Color( status == .danger ? "Risk1Color\(settingViewModel.getRiskLevelColor(level: status))" : "RiskColor\(settingViewModel.getRiskLevelColor(level: status))"))
+                    .foregroundStyle(status == .danger ? Color.risk1Color(settingViewModel.getRiskLevelColor(level: status)) : Color.riskColor(settingViewModel.getRiskLevelColor(level: status)))
             }
         }
     }
@@ -191,7 +191,7 @@ private struct ColorPickerView: View {
                 .scaledToFit()
                 .frame(width: 36)
             
-                .foregroundStyle(Color( status == .danger ? "Risk1Color\(settingViewModel.getRiskLevelColor(level: status))" : "RiskColor\(settingViewModel.getRiskLevelColor(level: status))"))
+                .foregroundStyle(status == .danger ? Color.risk1Color(settingViewModel.getRiskLevelColor(level: status)) : Color.riskColor(settingViewModel.getRiskLevelColor(level: status)))
             Image(systemName: "chevron.down")
                 .foregroundStyle(Color.gray500)
             


### PR DESCRIPTION
## 개요

Closes #60

상세 설정 > 경고 아이콘 색상 변경에서 색을 선택해도 팔레트/아이콘/미리보기에 색이 표시되지 않던 버그 수정.

## 원인

`SettingView` 3곳(팔레트 원형, 시트 키보드 미리보기, 설정 행 아이콘)이 `Color("RiskColor\(n)")` 문자열 조회 사용 — 번들 미지정 시 **메인 번들**을 검색하는데, 색 에셋은 모듈화(#28) 때 **DesignSystem 패키지 번들**로 이동 → 색을 못 찾아 투명 렌더. PR #53에서 키보드 쪽을 고친 것과 동일한 버그 클래스로, 앱 쪽 잔존 사례.

## 변경

- 3곳 모두 올바른 번들을 지정하는 `Color.riskColor(_:)` / `Color.risk1Color(_:)` 헬퍼로 교체

## 검증

- Xcode 27.0 베타 / 26.5 BUILD SUCCEEDED ✅
- 실기기 확인: 색상 팔레트 7색 표시, 선택 시 행 아이콘·시트 미리보기 즉시 반영, 키보드 배너 색도 설정값 따라가는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)