### PR TITLE
feat: #62 - 키 햅틱을 시스템 키보드 느낌으로 개선

### DIFF
--- a/Sources/KeyboardKit/Service/Haptic.swift
+++ b/Sources/KeyboardKit/Service/Haptic.swift
@@ -8,6 +8,19 @@ import Foundation
 import UIKit
 
 public class Haptic {
+    // 키 입력 전용 — 매번 생성하면 첫 진동이 지연되므로 재사용 + prepare()로 즉각 반응
+    private static let keyPressGenerator: UIImpactFeedbackGenerator = {
+        let generator = UIImpactFeedbackGenerator(style: .rigid)
+        generator.prepare()
+        return generator
+    }()
+
+    /// iOS 시스템 키보드에 근접한 짧고 단단한 틱
+    public static func keyPress() {
+        keyPressGenerator.impactOccurred(intensity: 0.65)
+        keyPressGenerator.prepare()
+    }
+
     public static func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
         let generator = UINotificationFeedbackGenerator()
         generator.notificationOccurred(type)

--- a/WatchOutkeyboard/View/KeyboardView.swift
+++ b/WatchOutkeyboard/View/KeyboardView.swift
@@ -128,7 +128,7 @@ struct KeyboardView: View {
             .onChanged { value in
                 if !pressedKeys.contains(key) {
                     pressedKeys.insert(key)
-                    Haptic.impact(style: .soft)
+                    Haptic.keyPress()
                     startLongPress(for: key)
                 }
 


### PR DESCRIPTION
## 개요

Closes #62 — #56 키 햅틱의 질감 개선.

## 변경

- **`Haptic.keyPress()` 신설** (KeyboardKit): 제너레이터를 재사용하고 매 호출 후 `prepare()` — 기존처럼 호출마다 생성하면 Taptic Engine 웜업 때문에 첫 진동이 늦거나 약함. 시스템 키보드 느낌의 핵심인 "즉각성" 확보
- **질감**: `.soft` → **`.rigid` + intensity 0.65** — 시스템 키보드의 짧고 단단한 틱에 공개 API로 가장 근접한 조합 (시스템 햅틱 자체는 비공개 API라 100% 동일 재현 불가)

## 검증

- Xcode 27.0 베타 / 26.5 키보드 스킴 BUILD SUCCEEDED ✅
- 실기기 확인: 시스템 키보드와 번갈아 타건하며 비교. 미세 조정 옵션: intensity 0.5~0.8, 또는 `.light`로 스타일 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)