### PR TITLE
refactor: #64 - composition root 도입 (Features→Data 의존 차단)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,12 +61,11 @@ let package = Package(
         ),
 
         // MARK: - 화면 (Auth/Home/Group/Main/Setting/Experience 폴더로 구분)
-        // Data 의존은 Repository 기본값 주입 때문 — composition root 도입 시 제거 예정
+        // Data 의존 없음 — 구현체 조립은 앱 타깃(composition root)에서
         .target(
             name: "Features",
             dependencies: [
                 "Domain",
-                "Data",
                 "DesignSystem",
                 "Platform",
                 .product(name: "DotLottie", package: "dotlottie-ios"),

--- a/Sources/Data/Manager/TokenManager.swift
+++ b/Sources/Data/Manager/TokenManager.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import Domain
 import Platform
 
-public final class TokenManager {
+public final class TokenManager: TokenStore {
     public static let shared = TokenManager()
 
     private let keychain = KeychainStorage()

--- a/Sources/Data/Network/APIClient.swift
+++ b/Sources/Data/Network/APIClient.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Domain
 import Platform
 
 public struct APIClient {

--- a/Sources/Domain/Error/APIError.swift
+++ b/Sources/Domain/Error/APIError.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - Validation Error Models
 public struct ValidationErrorResponse: Decodable {
-    let detail: [ValidationErrorDetail]
+    public let detail: [ValidationErrorDetail]
 }
 
 public struct ValidationErrorDetail: Decodable {

--- a/Sources/Domain/Repository/TokenStore.swift
+++ b/Sources/Domain/Repository/TokenStore.swift
@@ -1,0 +1,18 @@
+//
+//  TokenStore.swift
+//  WatchOut
+//
+//  Created by 어재선 on 6/12/26.
+//
+
+import Foundation
+
+public protocol TokenStore {
+    func saveDeviceToken(_ token: String)
+    func saveAccessToken(_ token: String)
+    func saveRefreshToken(_ token: String)
+    func loadAccessToken() -> String?
+    func loadRefreshToken() -> String?
+    func loadDeviceToken() -> String?
+    func clearAllTokens()
+}

--- a/Sources/Domain/Service/UserManager.swift
+++ b/Sources/Domain/Service/UserManager.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Combine
-import Domain
 
 
 public final class UserManager: ObservableObject {

--- a/Sources/Features/AppDependencies.swift
+++ b/Sources/Features/AppDependencies.swift
@@ -1,0 +1,30 @@
+//
+//  AppDependencies.swift
+//  WatchOut
+//
+//  Created by 어재선 on 6/12/26.
+//
+
+import Foundation
+import Domain
+
+/// 앱의 의존성 묶음. composition root(앱 진입점)에서 한 번만 조립해 화면으로 흘려보낸다.
+/// Features는 Domain 프로토콜만 알며, 구현체 선택은 전적으로 조립 지점의 책임이다.
+public struct AppDependencies {
+    public let authRepository: AuthRepository
+    public let groupRepository: GroupRepository
+    public let tokenStore: TokenStore
+    public let userManager: UserManager
+
+    public init(
+        authRepository: AuthRepository,
+        groupRepository: GroupRepository,
+        tokenStore: TokenStore,
+        userManager: UserManager
+    ) {
+        self.authRepository = authRepository
+        self.groupRepository = groupRepository
+        self.tokenStore = tokenStore
+        self.userManager = userManager
+    }
+}

--- a/Sources/Features/Auth/Login/LoginView.swift
+++ b/Sources/Features/Auth/Login/LoginView.swift
@@ -8,14 +8,19 @@
 import SwiftUI
 import Domain
 import DesignSystem
-import Data
 import Platform
 
 public struct LoginView: View {
-    @StateObject private var loginViewModel = LoginViewModel()
+    @StateObject private var loginViewModel: LoginViewModel
     @EnvironmentObject private var appState: AppState
     
-    public init() { }
+    public init(dependencies: AppDependencies) {
+        _loginViewModel = StateObject(wrappedValue: LoginViewModel(
+            repository: dependencies.authRepository,
+            userManager: dependencies.userManager,
+            tokenStore: dependencies.tokenStore
+        ))
+    }
     
     public var body: some View {
         

--- a/Sources/Features/Auth/Login/LoginViewModel.swift
+++ b/Sources/Features/Auth/Login/LoginViewModel.swift
@@ -9,7 +9,6 @@ import Foundation
 import Combine
 import KakaoSDKUser
 import Domain
-import Data
 import Platform
 
 final class LoginViewModel: ObservableObject {
@@ -18,16 +17,16 @@ final class LoginViewModel: ObservableObject {
 
     private let repository: AuthRepository
     private let userManager: UserManager
-    private let tokenManager: TokenManager
+    private let tokenStore: TokenStore
 
     init(
-        repository: AuthRepository = AuthRepositoryImpl(),
-        userManager: UserManager = .shared,
-        tokenManager: TokenManager = .shared
+        repository: AuthRepository,
+        userManager: UserManager,
+        tokenStore: TokenStore
     ) {
         self.repository = repository
         self.userManager = userManager
-        self.tokenManager = tokenManager
+        self.tokenStore = tokenStore
     }
 
     // MARK: - 로그인 처리 함수
@@ -71,10 +70,10 @@ final class LoginViewModel: ObservableObject {
             do {
                 let result = try await repository.loginWithKakao(
                     accessToken: kakaoToken,
-                    deviceToken: tokenManager.loadDeviceToken()
+                    deviceToken: tokenStore.loadDeviceToken()
                 )
                 userManager.setCurrentUser(result.user)
-                tokenManager.saveAccessToken(result.accessToken)
+                tokenStore.saveAccessToken(result.accessToken)
                 Log.debug("서버 로그인 성공! 사용자: \(result.user.nickname)")
                 isLoading = false
                 completion(true)

--- a/Sources/Features/Auth/Onboarding/OnboardingView.swift
+++ b/Sources/Features/Auth/Onboarding/OnboardingView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import DotLottie
 import Domain
 import Platform
-import Data
 import DesignSystem
 
 public struct OnboardingView: View {

--- a/Sources/Features/Group/CreateGroupView.swift
+++ b/Sources/Features/Group/CreateGroupView.swift
@@ -11,9 +11,14 @@ import DesignSystem
 
 public struct CreateGroupView: View {
     @EnvironmentObject private var pathModel: PathModel
-    @StateObject private var groupViewModel = GroupViewModel()
+    @StateObject private var groupViewModel: GroupViewModel
 
-    public init() { }
+    public init(dependencies: AppDependencies) {
+        _groupViewModel = StateObject(wrappedValue: GroupViewModel(
+            repository: dependencies.groupRepository,
+            userManager: dependencies.userManager
+        ))
+    }
 
     public var body: some View {
         VStack {
@@ -168,8 +173,4 @@ public struct CreateGroupView: View {
             Text(groupViewModel.errorMessage)
         }
     }
-}
-
-#Preview {
-    CreateGroupView()
 }

--- a/Sources/Features/Group/GroupViewModel.swift
+++ b/Sources/Features/Group/GroupViewModel.swift
@@ -9,7 +9,6 @@ import Foundation
 import Combine
 import Domain
 import Platform
-import Data
 
 class GroupViewModel: ObservableObject {
 
@@ -70,8 +69,8 @@ class GroupViewModel: ObservableObject {
             nickname: "",
             profileImage: ""
         ),
-        repository: GroupRepository = GroupRepositoryImpl(),
-        userManager: UserManager = .shared
+        repository: GroupRepository,
+        userManager: UserManager
     ) {
         self.groupName = groupName
         self.userName = userName

--- a/Sources/Features/Group/JoinGroupView.swift
+++ b/Sources/Features/Group/JoinGroupView.swift
@@ -11,9 +11,14 @@ import DesignSystem
 
 public struct JoinGroupView: View {
     @EnvironmentObject private var pathModel: PathModel
-    @StateObject private var groupViewModel = GroupViewModel()
+    @StateObject private var groupViewModel: GroupViewModel
 
-    public init() { }
+    public init(dependencies: AppDependencies) {
+        _groupViewModel = StateObject(wrappedValue: GroupViewModel(
+            repository: dependencies.groupRepository,
+            userManager: dependencies.userManager
+        ))
+    }
 
     public var body: some View {
         VStack {
@@ -174,8 +179,4 @@ public struct JoinGroupView: View {
         
     }
 
-}
-
-#Preview {
-    JoinGroupView()
 }

--- a/Sources/Features/Group/ManagementGroupView.swift
+++ b/Sources/Features/Group/ManagementGroupView.swift
@@ -8,17 +8,21 @@
 import SwiftUI
 import UIKit
 import Domain
-import Data
 import DesignSystem
 
 
 public struct ManagementGroupView: View {
     @EnvironmentObject private var pathModel: PathModel
-    @StateObject private var groupViewModel = GroupViewModel()
+    @StateObject private var groupViewModel: GroupViewModel
     @EnvironmentObject private var userManager: UserManager
     @State private var isToastShown: Bool = false
 
-    public init() { }
+    public init(dependencies: AppDependencies) {
+        _groupViewModel = StateObject(wrappedValue: GroupViewModel(
+            repository: dependencies.groupRepository,
+            userManager: dependencies.userManager
+        ))
+    }
 
     public var body: some View {
         
@@ -301,8 +305,4 @@ private struct ProfileView: View {
             
         }
     }
-}
-
-#Preview {
-    ManagementGroupView()
 }

--- a/Sources/Features/Home/Home/HomeView.swift
+++ b/Sources/Features/Home/Home/HomeView.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 import Domain
 import Platform
-import Data
 import DesignSystem
 
 public struct HomeView: View {
     @EnvironmentObject private var pathModel: PathModel
-    @StateObject private var homeViewModel: HomeViewModel = HomeViewModel()
+    @StateObject private var homeViewModel: HomeViewModel
     
-    public init() { }
+    public init(dependencies: AppDependencies) {
+        _homeViewModel = StateObject(wrappedValue: HomeViewModel(userManager: dependencies.userManager))
+    }
     
     public var body: some View {
         ScrollView(showsIndicators: false){
@@ -287,9 +288,4 @@ private struct CustomDivider: View {
             .frame(height: 8)
             .foregroundStyle(Color.gray100)
     }
-}
-
-
-#Preview {
-    HomeView()
 }

--- a/Sources/Features/Home/Home/HomeViewModel.swift
+++ b/Sources/Features/Home/Home/HomeViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Data
+import Domain
 import Platform
 
 class HomeViewModel: ObservableObject {
@@ -16,7 +16,7 @@ class HomeViewModel: ObservableObject {
     
     private let userManager: UserManager
 
-    init(userManager: UserManager = .shared) {
+    init(userManager: UserManager) {
         self.userManager = userManager
         userManager.loadUserFromUserDefaults()
     }

--- a/Sources/Features/Main/MainTabView.swift
+++ b/Sources/Features/Main/MainTabView.swift
@@ -7,16 +7,22 @@
 
 import SwiftUI
 import Domain
-import Data
 import Platform
 import DesignSystem
 
 public struct MainTabView: View {
     @EnvironmentObject private var pathModel: PathModel
-    @StateObject private var mainTabViewModel = MainTabViewModel()
+    @StateObject private var mainTabViewModel: MainTabViewModel
+    private let dependencies: AppDependencies
     @EnvironmentObject private var appState: AppState
 
-    public init() { }
+    public init(dependencies: AppDependencies) {
+        self.dependencies = dependencies
+        _mainTabViewModel = StateObject(wrappedValue: MainTabViewModel(
+            repository: dependencies.authRepository,
+            userManager: dependencies.userManager
+        ))
+    }
 
     public var body: some View {
         VStack(spacing:0) {
@@ -61,8 +67,8 @@ public struct MainTabView: View {
                     Button("취소", role: .cancel) { }
                     Button("로그아웃", role: .destructive) {
                         appState.isLoggedIn = false
-                        TokenManager.shared.clearAllTokens()
-                        UserManager.shared.clearUser()
+                        dependencies.tokenStore.clearAllTokens()
+                        dependencies.userManager.clearUser()
                     }
                 } message: {
                     Text("로그아웃 하시면 자동으로 그룹에서 강퇴됩니다.")
@@ -72,8 +78,8 @@ public struct MainTabView: View {
                     Button("탈퇴하기", role: .destructive) {
                         mainTabViewModel.loginDelete() {
                             appState.isLoggedIn = false
-                            TokenManager.shared.clearAllTokens()
-                            UserManager.shared.clearUser()
+                            dependencies.tokenStore.clearAllTokens()
+                            dependencies.userManager.clearUser()
                         }
                         
                     }
@@ -86,7 +92,7 @@ public struct MainTabView: View {
             .background(Color.gray100)
             
             if mainTabViewModel.selectedTab == .homeView {
-                HomeView()
+                HomeView(dependencies: dependencies)
                     .navigationBarBackButtonHidden()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if mainTabViewModel.selectedTab == .settingView {
@@ -124,8 +130,4 @@ public struct MainTabView: View {
         }
         
     }
-}
-
-#Preview {
-    MainTabView()
 }

--- a/Sources/Features/Main/MainTabViewModel.swift
+++ b/Sources/Features/Main/MainTabViewModel.swift
@@ -9,7 +9,6 @@ import Foundation
 import Combine
 import DesignSystem
 import Domain
-import Data
 import Platform
 
 class MainTabViewModel: ObservableObject {
@@ -23,8 +22,8 @@ class MainTabViewModel: ObservableObject {
 
     init(
         selectedTab: WatchOutTab = .homeView,
-        repository: AuthRepository = AuthRepositoryImpl(),
-        userManager: UserManager = .shared
+        repository: AuthRepository,
+        userManager: UserManager
     ) {
         self.selectedTab = selectedTab
         self.repository = repository

--- a/Sources/Features/Setting/Plan/PlanView.swift
+++ b/Sources/Features/Setting/Plan/PlanView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import Domain
 import DesignSystem
-import Data
 
 public struct PlanView: View {
     @EnvironmentObject var pathModel: PathModel

--- a/Sources/Features/Setting/Setting/SettingView.swift
+++ b/Sources/Features/Setting/Setting/SettingView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import Domain
-import Data
 import DesignSystem
 
 public struct SettingView: View {

--- a/Sources/Features/Setting/Setting/SettingViewModel.swift
+++ b/Sources/Features/Setting/Setting/SettingViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Data
 import Platform
 import Domain
 

--- a/WatchOut/App/ContentView.swift
+++ b/WatchOut/App/ContentView.swift
@@ -11,17 +11,18 @@ import Platform
 import Features
 
 struct ContentView: View {
+    let dependencies: AppDependencies
     @EnvironmentObject private var appState: AppState
 
     var body: some View {
         if !appState.isLoggedIn {
-            LoginView()
+            LoginView(dependencies: dependencies)
                 .navigationBarBackButtonHidden()
         } else if !appState.isOnboardingCompleted {
             OnboardingView()
                 .navigationBarBackButtonHidden()
         } else {
-            MainTabView()
+            MainTabView(dependencies: dependencies)
                 .navigationBarBackButtonHidden()
         }
     }

--- a/WatchOut/App/RootView.swift
+++ b/WatchOut/App/RootView.swift
@@ -13,6 +13,14 @@ import Platform
 import Features
 
 struct RootView: View {
+    // Composition Root — 구현체 선택은 이 한 곳에서만
+    private let dependencies = AppDependencies(
+        authRepository: AuthRepositoryImpl(),
+        groupRepository: GroupRepositoryImpl(),
+        tokenStore: TokenManager.shared,
+        userManager: UserManager.shared
+    )
+
     @StateObject private var pathModel = PathModel()
     @StateObject private var appState = AppState(
         isLoggedIn: TokenManager.shared.loadAccessToken().map { !$0.isEmpty } ?? false,
@@ -22,7 +30,7 @@ struct RootView: View {
 
     var body: some View {
         NavigationStack(path: $pathModel.paths) {
-            ContentView()
+            ContentView(dependencies: dependencies)
                 .navigationDestination(for: PathType.self) { pathType in
                     destination(for: pathType)
                 }
@@ -37,19 +45,19 @@ struct RootView: View {
     private func destination(for pathType: PathType) -> some View {
         switch pathType {
         case .mainTabView:
-            MainTabView()
+            MainTabView(dependencies: dependencies)
                 .navigationBarBackButtonHidden()
         case .exprienceView:
             ExperienceView()
                 .navigationBarBackButtonHidden()
         case .createGroupView:
-            CreateGroupView()
+            CreateGroupView(dependencies: dependencies)
                 .navigationBarBackButtonHidden()
         case .joinGroupView:
-            JoinGroupView()
+            JoinGroupView(dependencies: dependencies)
                 .navigationBarBackButtonHidden()
         case .managementGroupView:
-            ManagementGroupView()
+            ManagementGroupView(dependencies: dependencies)
                 .navigationBarBackButtonHidden()
         case .planView:
             PlanView()


### PR DESCRIPTION
## 개요

Closes #64 — PR #53에서 예고한 후속 작업. "객체를 어디서 만들 것인가"의 답을 앱 진입점 한 곳으로 통일.

## 변경

### Composition Root
- **`AppDependencies`** (Features): authRepository / groupRepository / tokenStore / userManager 묶음
- **`RootView`가 유일한 조립 지점** — `AuthRepositoryImpl()` 등 구현체 생성은 앱 타깃에서만. ContentView·화면 7곳에 init으로 전달
- ViewModel 4개(Login/MainTab/Group/Home)의 `= Impl()` 기본값 제거, View 6곳 `@StateObject(wrappedValue:)` init 주입

### 타입 이동 (Features가 Data를 안 보게)
- `UserManager`: Data → **Domain** (세션 저장소, Domain의 User 엔티티와 동거)
- `TokenStore` 프로토콜 신설(Domain), `TokenManager: TokenStore` 채택(Data)
- `APIError`: Data → **Domain** — Repository 프로토콜이 던지는 에러는 도메인 소속 (컴파일러가 Features의 Data 참조를 잡아내며 드러난 이동 대상)

### 의존 차단
- **Package.swift에서 Features의 Data 의존 제거** — 이제 Features에서 `import Data`나 `GroupRepositoryImpl()` 작성 시 컴파일 에러. 의존 규칙이 리뷰가 아닌 빌드로 강제됨

### 기타
- MainTabView의 `.shared` 직접 호출(로그아웃 시 토큰/유저 정리) → dependencies 경유
- 기본 init이 사라진 화면 Preview 5곳 제거 (Features는 Impl을 모르므로 Preview에서 조립 불가)

## 최종 의존 그래프

```
앱(조립) ──> Features ──> Domain ←── Data(구현)
                └──> DesignSystem, Platform
```

## 검증

- Xcode 27.0 베타 / 26.5 BUILD SUCCEEDED ✅
- 실기기 확인: 로그인 → 그룹 플로우 → 로그아웃/탈퇴 (의존성 전달 경로가 전부 바뀜)

🤖 Generated with [Claude Code](https://claude.com/claude-code)