### PR TITLE
fix: #72 - 키보드 활성화 감지 정상화

### DIFF
--- a/Sources/Platform/Service/KeyboardPermissionManager.swift
+++ b/Sources/Platform/Service/KeyboardPermissionManager.swift
@@ -8,37 +8,28 @@
 import UIKit
 
 public struct KeyboardPermissionManager {
-    
+
+    /// 키보드 익스텐션 번들 ID. 앱 번들 ID(com.jaesuneo.WatchOut)에서 파생.
+    private static var keyboardBundleID: String {
+        (Bundle.main.bundleIdentifier ?? "") + ".WatchOutkeyboard"
+    }
+
+    /// 사용자가 설정에서 우리 키보드를 추가했는지 여부.
+    /// iOS는 설치된 서드파티 키보드의 번들 ID를 UserDefaults의 "AppleKeyboards"에 보관한다.
     public static func isKeyboardEnabled() -> Bool {
-        guard Thread.isMainThread else {
-            print("Warning: isKeyboardEnabled() was called from a background thread.")
+        guard let keyboards = UserDefaults.standard.object(forKey: "AppleKeyboards") as? [String] else {
+            Log.debug("AppleKeyboards 목록을 읽을 수 없음")
             return false
         }
-        
-        let activeKeyboards = UITextInputMode.activeInputModes
-        print("activeKeyboards: \(activeKeyboards)")
-        
-        let isEnabled = activeKeyboards.contains { inputMode in
-        
-            if let language = inputMode.primaryLanguage {
-                print(language)
-                return language.contains("watchout")
-            }
-            return false
-        }
-        
-        print("키보드 활성화 상태: \(isEnabled)")
+        let isEnabled = keyboards.contains(keyboardBundleID)
+        Log.debug("키보드 활성화 상태: \(isEnabled) (id: \(keyboardBundleID))")
         return isEnabled
     }
 
     public static func openAppSettings() async {
         guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-        
-        print("Opening app settings: \(url)")
-        
         await MainActor.run {
             UIApplication.shared.open(url)
         }
     }
 }
-


### PR DESCRIPTION
## 개요

Closes #72 — `KeyboardPermissionManager.isKeyboardEnabled()`가 키보드 설치 여부를 판단 못 하던 버그 수정.

## 원인

기존 구현은 `UITextInputMode.activeInputModes`의 `primaryLanguage`에 `"watchout"`이 포함되는지 검사:
1. `primaryLanguage`는 **언어 코드**(`ko-KR`, `en-US`)를 반환 — 키보드 Info.plist의 `PrimaryLanguage` 커스텀 값이 아니라 비교 자체가 성립 불가
2. PrimaryLanguage를 `ko`로 정상화한 #70 이후엔 항상 false
3. `activeInputModes`는 현재 입력 세션 기준이라 앱 안에서 "내 키보드 설치됨" 판단용으로 부적합

## 변경

- **표준 방식으로 교체**: `UserDefaults.standard`의 `AppleKeyboards`(설치된 서드파티 키보드 번들 ID 배열)에 키보드 익스텐션 번들 ID가 있는지 확인
- 번들 ID는 `Bundle.main.bundleIdentifier + ".WatchOutkeyboard"`로 파생 — 하드코딩/오타 방지
- 디버그 `print` → `Log`

## 검증

- Xcode 27.0 베타 / 26.5 BUILD SUCCEEDED ✅
- 실기기 확인 필수: 설정에서 키보드 추가 전/후 온보딩의 "키보드 설정됨" 인식이 정확한지

🤖 Generated with [Claude Code](https://claude.com/claude-code)