### PR TITLE
fix: #74 - 그룹 입장 409 처리 및 isCreateGroup 상태 desync 해결

### DIFF
--- a/Sources/Data/Network/APIClient.swift
+++ b/Sources/Data/Network/APIClient.swift
@@ -71,6 +71,7 @@ extension APIError {
         case 401: self = .unauthorized
         case 403: self = .forbidden
         case 404: self = .notFound
+        case 409: self = .conflict
         case 500...599: self = .serverError
         default: self = .unknown(statusCode: statusCode, message: nil)
         }

--- a/Sources/Domain/Error/APIError.swift
+++ b/Sources/Domain/Error/APIError.swift
@@ -54,6 +54,7 @@ public enum APIError: Error {
     case unauthorized           // 401
     case forbidden              // 403
     case notFound               // 404
+    case conflict               // 409
     case serverError            // 500
     case networkError
     case decodingError
@@ -71,6 +72,8 @@ public enum APIError: Error {
             return "접근 권한이 없습니다."
         case .notFound:
             return "요청한 정보를 찾을 수 없습니다."
+        case .conflict:
+            return "이미 그룹에 속해 있습니다."
         case .serverError:
             return "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
         case .networkError:

--- a/Sources/Presentation/Group/GroupViewModel.swift
+++ b/Sources/Presentation/Group/GroupViewModel.swift
@@ -200,6 +200,14 @@ extension GroupViewModel {
             isJoinGroup = true
             showError = false
         } catch {
+            // 409: 이미 그룹에 속해 있음 → 에러 대신 관리 화면으로 복귀
+            if case .conflict = (error as? APIError) {
+                Log.debug("joinGroup 409: 이미 그룹 소속 → 관리 화면으로")
+                isCreate = true
+                isJoinGroup = true
+                showError = false
+                return
+            }
             Log.error("joinGroup 실패: \(error)")
             handleError(error)
         }
@@ -234,7 +242,11 @@ extension GroupViewModel {
             Log.debug("infoGroup 성공: 멤버 \(info.members.count)명")
         } catch {
             isLoading = false
-            SharedUserDefaults.isCreateGroup = false
+            // 그룹이 실제로 없을 때(404)만 상태를 내린다.
+            // 네트워크/서버 일시 오류로 홈이 "입장하기"로 바뀌어 재입장→409 충돌하는 desync 방지.
+            if case .notFound = (error as? APIError) {
+                SharedUserDefaults.isCreateGroup = false
+            }
             Log.error("infoGroup 실패: \(error)")
             handleError(error)
         }
@@ -267,6 +279,14 @@ extension GroupViewModel {
             isCreate = true
             groupName = ""
         } catch {
+            // 409: 이미 그룹에 속해 있음 → 에러 대신 관리 화면으로 복귀
+            if case .conflict = (error as? APIError) {
+                Log.debug("createGroup 409: 이미 그룹 소속 → 관리 화면으로")
+                isCreate = true
+                groupName = ""
+                showError = false
+                return
+            }
             Log.error("createGroup 실패: \(error)")
             handleError(error)
         }

--- a/Sources/Presentation/Home/Home/HomeView.swift
+++ b/Sources/Presentation/Home/Home/HomeView.swift
@@ -15,7 +15,10 @@ public struct HomeView: View {
     @StateObject private var homeViewModel: HomeViewModel
     
     public init(dependencies: AppDependencies) {
-        _homeViewModel = StateObject(wrappedValue: HomeViewModel(userManager: dependencies.userManager))
+        _homeViewModel = StateObject(wrappedValue: HomeViewModel(
+            userManager: dependencies.userManager,
+            groupRepository: dependencies.groupRepository
+        ))
     }
     
     public var body: some View {
@@ -44,7 +47,7 @@ public struct HomeView: View {
                 .frame(height: 16)
             VStack(spacing: 8) {
                 
-                if SharedUserDefaults.isCreateGroup {
+                if homeViewModel.isInGroup {
                     GroupBoxRowView(title: "내 그룹 관리", subTitle: "가족 그룹을 관리해 보세요", imageName: "maingroup3")
                         .onTapGesture {
                             pathModel.paths.append(.managementGroupView)
@@ -82,6 +85,10 @@ public struct HomeView: View {
                 UserManager.shared.loadUserFromUserDefaults()
 
             }
+        }
+        .task {
+            // 홈 진입 시 서버 기준으로 그룹 소속 여부 동기화 (로컬 플래그 desync 방지)
+            await homeViewModel.syncGroupMembership()
         }
         
     }

--- a/Sources/Presentation/Home/Home/HomeViewModel.swift
+++ b/Sources/Presentation/Home/Home/HomeViewModel.swift
@@ -13,23 +13,46 @@ class HomeViewModel: ObservableObject {
     @Published var risk2Count: Int = 0
     @Published var risk3Count: Int = 0
     @Published var username:String = "위허메"
-    
-    private let userManager: UserManager
+    // 첫 렌더는 캐시값으로(깜빡임 방지), 이후 syncGroupMembership()이 서버 기준으로 보정한다.
+    @Published var isInGroup: Bool = SharedUserDefaults.isCreateGroup
 
-    init(userManager: UserManager) {
+    private let userManager: UserManager
+    private let groupRepository: GroupRepository
+
+    init(userManager: UserManager, groupRepository: GroupRepository) {
         self.userManager = userManager
+        self.groupRepository = groupRepository
         userManager.loadUserFromUserDefaults()
     }
-    
+
     func loadData() {
         userManager.loadUserFromUserDefaults()
 
         if let username = userManager.currentUser?.nickname {
             self.username = username
         }
-        
+
         risk2Count = SharedUserDefaults.riskLevel2Count
         risk3Count = SharedUserDefaults.riskLevel3Count
     }
-    
+
+    /// 앱/홈 진입 시 서버를 기준으로 그룹 소속 여부를 동기화한다.
+    /// 로컬 플래그(isCreateGroup)만 믿지 않고 실제 멤버십을 확인해 desync를 방지.
+    @MainActor
+    func syncGroupMembership() async {
+        guard let userId = userManager.currentUser?.userId, !userId.isEmpty else { return }
+        do {
+            _ = try await groupRepository.fetchGroupInfo(userId: userId)
+            isInGroup = true
+            SharedUserDefaults.isCreateGroup = true
+        } catch {
+            // 그룹이 실제로 없을 때(404)만 false로. 네트워크/서버 일시 오류는 기존 상태 유지.
+            if case .notFound = (error as? APIError) {
+                isInGroup = false
+                SharedUserDefaults.isCreateGroup = false
+            }
+            Log.error("syncGroupMembership 실패: \(error)")
+        }
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈
Closes #74

## 문제
그룹 "입장하기"/"만들기"가 동작하지 않음.
1. **404 (사용자 없음)**: 백엔드가 존재하지 않는 `user_id`에 `404 {"detail":"사용자를 찾을 수 없음"}` 반환 → 앱은 "요청한 정보를 찾을 수 없습니다." 표시. (재로그인으로 user_id 정상화 시 해소)
2. **409 (이미 그룹 소속)**: 재로그인 후 입장 시 `409 Conflict`. `APIError`에 409 케이스가 없어 "알 수 없는 오류 (코드: 409)"로 표시됨.
3. **상태 desync (근본 원인)**: 홈은 로컬 플래그 `isCreateGroup`만 보고 "관리/만들기·입장"을 결정하는데, 이 플래그는 만들기·참여 시에만 갱신되고 info 실패 시 무조건 false로 리셋됨 → 서버 실제 상태와 어긋나 재입장 시 409.

> 백엔드 OpenAPI 명세상 join/create는 200·201/422만 문서화돼 있고, 404·409는 런타임 비즈니스 로직 응답으로 확인됨 (라이브 호출로 재현).

## 변경 사항
**409 / 에러 처리**
- `APIError`에 `.conflict`(409) 추가 + 메시지 "이미 그룹에 속해 있습니다."
- `APIClient` 상태코드 매핑에 `409 → .conflict`
- `fetchGroupInfo` 실패 시 **notFound(404)일 때만** `isCreateGroup=false` (일시 오류엔 유지)
- `joinGroup`/`createGroup`에서 **409 수신 시 에러 대신 관리 화면으로 복귀**

**근본 해법: 서버 기준 동기화**
- 홈 진입 시 서버 `info` 조회로 실제 그룹 소속 여부를 동기화 (로컬 플래그만 믿지 않음)
- `HomeViewModel`: `groupRepository` 주입, `@Published isInGroup`, `syncGroupMembership()` (소속이면 true / 404면 false / 일시 오류는 기존 유지)
- `HomeView`: 그룹 카드 분기를 `isInGroup`(반응형)으로 변경, `.task`에서 진입 시 동기화
- 결과: "만들기·참여해야만 갱신"되던 구조 → **앱 켜서 홈 들어올 때마다 서버 기준 자동 보정**

## 검증
- Presentation 스킴 빌드 통과 (Xcode 26.5 CLI, exit 0) — 두 커밋 각각 확인
- 라이브 백엔드 응답 확인: 없는 user_id → 404, verify → 200, create 빈요청 → 422

## 비고
- 대상 base는 신규 아키텍처가 있는 `refactor/#31-naming-cleanup`. main(배포판/구 Moya 코드)에는 별도 반영 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)