### PR TITLE
fix: #76 - 앱 재설치 후 Keychain 토큰 잔존으로 로그인 화면 건너뜀 해결

### DIFF
--- a/Sources/Platform/Service/SharedUserDefaults.swift
+++ b/Sources/Platform/Service/SharedUserDefaults.swift
@@ -30,6 +30,7 @@ public struct SharedUserDefaults {
         case groupCode = "groupCode"
         case joinId = "joinId"
         case createGroup = "isCreateGroup"
+        case hasLaunchedBefore = "hasLaunchedBefore"
         case WarningNotification = "isWarningNotification"
         case DangerNotification = "isDangerNotification"
         case WarningHaptic = "isWarningHaptic"
@@ -79,6 +80,15 @@ public struct SharedUserDefaults {
             return shared.object(forKey: SettingsKey.createGroup.rawValue) as? Bool ?? false
         } set {
             shared.set(newValue, forKey: SettingsKey.createGroup.rawValue)
+        }
+    }
+
+    //MARK: - 첫 실행 여부 (앱 삭제 시 UserDefaults는 지워지나 Keychain은 남음 → 재설치 감지용)
+    public static var hasLaunchedBefore: Bool {
+        get {
+            return shared.bool(forKey: SettingsKey.hasLaunchedBefore.rawValue)
+        } set {
+            shared.set(newValue, forKey: SettingsKey.hasLaunchedBefore.rawValue)
         }
     }
     

--- a/WatchOut/App/AppDelegate.swift
+++ b/WatchOut/App/AppDelegate.swift
@@ -8,13 +8,15 @@
 import KakaoSDKAuth
 import UIKit
 import Data
+import Platform
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
-    
+
     func application(
         _ application: UIApplication, didFinishLaunchingWithOptions
         launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
+        clearKeychainOnFreshInstall()
         UNUserNotificationCenter.current().delegate = self
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { granted, error in
@@ -30,8 +32,18 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         
         return true
     }
-    
-    
+
+    /// 앱 재설치 감지 시 Keychain 정리.
+    /// iOS Keychain은 앱 삭제 후에도 남아, 잔존 토큰으로 isLoggedIn=true가 되어
+    /// 로그인 화면을 건너뛰는 문제를 방지한다. (UserDefaults 플래그는 삭제 시 함께 지워짐)
+    private func clearKeychainOnFreshInstall() {
+        guard !SharedUserDefaults.hasLaunchedBefore else { return }
+        TokenManager.shared.clearAllTokens()
+        SharedUserDefaults.hasLaunchedBefore = true
+        print("🧹 첫 실행 감지: 잔존 Keychain 토큰/유저 정리 완료")
+    }
+
+
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         print("✅ Device Token: \(token)")


### PR DESCRIPTION
## 관련 이슈
Closes #76

## 문제
앱 삭제 후 **재설치하면 로그인 화면이 나타나지 않고** 바로 온보딩/메인으로 진입. (시뮬레이터·실기기 모두 재현)

## 원인
- 토큰은 Keychain(`kSecClassGenericPassword`)에 저장됨. **iOS Keychain은 앱 삭제 시 지워지지 않음**(기기 초기화 전까지 잔존).
- 재설치 시 `loadAccessToken()`이 잔존 토큰 반환 → `isLoggedIn=true` → `ContentView`가 로그인 화면을 건너뜀.
- 첫 실행 시 Keychain 정리 로직 부재.

> 부수효과: 삭제 시 UserDefaults의 currentUser는 사라지나 토큰은 남아 "로그인됨인데 유저 없음" → 그룹 호출에 빈 user_id → 404 (#74 증상의 뿌리).

## 변경 사항
- `SharedUserDefaults`에 `hasLaunchedBefore` 플래그 추가 (App Group은 앱 삭제 시 키보드 익스텐션과 함께 제거되므로 재설치 감지에 사용 가능).
- `AppDelegate.didFinishLaunchingWithOptions` 시작 시 첫 실행이면 `TokenManager.shared.clearAllTokens()` 후 플래그 set → 이후 `isLoggedIn=false` → 로그인 화면 정상 표시.

## 검증
- WatchOut 앱 스킴 빌드 통과 (Xcode 26.5 CLI, exit 0)

## 비고
- #74(그룹 409/desync)와 별개 버그지만 같은 로그인/세션 뿌리. base는 `refactor/#31-naming-cleanup`. main(배포판)에는 별도 반영 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)