### PR TITLE
fix: #78 - 로그인할 때마다 온보딩 표시

### DIFF
--- a/Sources/Presentation/Auth/Login/LoginView.swift
+++ b/Sources/Presentation/Auth/Login/LoginView.swift
@@ -48,6 +48,9 @@ public struct LoginView: View {
                 Button {
                     loginViewModel.handleKakaoLogin { success in
                                    if success {
+                                       // 로그인할 때마다 온보딩을 다시 보여준다.
+                                       SharedUserDefaults.isOnboarding = false
+                                       appState.isOnboardingCompleted = false
                                        appState.isLoggedIn = true
                                    } else {
                                        print("최종 로그인 실패")

--- a/Sources/Presentation/Auth/Onboarding/OnboardingView.swift
+++ b/Sources/Presentation/Auth/Onboarding/OnboardingView.swift
@@ -93,6 +93,7 @@ private struct OnboardingFirstView: View {
 // MARK: - OnboardingSecondView
 private struct OnboardingSecondView: View {
     @EnvironmentObject private var pathModel: PathModel
+    @EnvironmentObject private var appState: AppState
     @FocusState private var focusedField: Field?
     @State private var hiddenText: String = ""
 
@@ -111,8 +112,9 @@ private struct OnboardingSecondView: View {
                 Spacer()
 
                 Button {
+                    // 온보딩 완료 → 메인으로 전환 (ContentView가 appState로 반응형 전환)
                     SharedUserDefaults.isOnboarding = true
-                    pathModel.paths.append(.mainTabView)
+                    appState.isOnboardingCompleted = true
                 } label: {
                     VStack {
                         Text("선택완료")


### PR DESCRIPTION
## 관련 이슈
Closes #78

## 원하는 플로우
- 첫 설치 → 로그인 → **온보딩**
- 로그아웃 → 로그인 → **온보딩**
- (로그인 유지된 채 앱 재실행 → 메인 직행)

## 문제
`SharedUserDefaults.isOnboarding`이 "선택완료" 시 영구 true → 재로그인해도 온보딩 건너뛰고 메인으로.

## 변경
- **로그인 성공 시**(LoginView) `isOnboarding=false` + `appState.isOnboardingCompleted=false` → 항상 온보딩 표시. (#77 강제 로그아웃 후 재로그인에도 정상 동작)
- **온보딩 선택완료 시**(OnboardingView) `isOnboarding=true` + `appState.isOnboardingCompleted=true` → ContentView가 appState로 메인 반응형 전환 (pathModel push 제거).

## 검증
- WatchOut 앱 스킴 빌드 통과 (Xcode 26.5 CLI, exit 0)

## 비고
- 로그인 유지 상태의 단순 앱 재실행은 로그인 이벤트가 아니므로 메인 직행(온보딩 미표시). base는 `refactor/#31-naming-cleanup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)