### PR TITLE
fix: #81 - 체험하기 1단계(위험 문장 감지) 전송 버튼 동작 추가

### DIFF
--- a/Sources/Presentation/Experience/ExperienceView.swift
+++ b/Sources/Presentation/Experience/ExperienceView.swift
@@ -132,18 +132,30 @@ public struct ExperienceView: View {
                 .font(.pretendard(size: 14, weight: .medium
                                  ))
                 CustomTextField(text: $text, enter: {
-                    
-                    if experienceType == .two {
-                        NotificationManager.instance.scheduleNotification(title: "위험한 문장이 반복 감지되었습니다.", subtitle: "필요하다면 즉시 신고를 도와드 수 있어요.", secondsLater: 1)
-                    }
-                    
-                    if experienceType == .two {
-                        experienceType = .three
-                        isEnter = true
+                    guard !text.isEmpty else { return }
+
+                    switch experienceType {
+                    case .one:
+                        // 1단계: 위험 문장 감지 → 입력 문장 전송 후 2단계로
                         sendtext = text
+                        isEnter = true
+                        experienceType = .two
                         text = ""
-                        
-                        
+
+                    case .two:
+                        // 2단계: 위험도 반응 확인 → 알림 후 3단계로
+                        NotificationManager.instance.scheduleNotification(
+                            title: "위험한 문장이 반복 감지되었습니다.",
+                            subtitle: "필요하다면 즉시 신고를 도와드릴 수 있어요.",
+                            secondsLater: 1
+                        )
+                        sendtext = text
+                        isEnter = true
+                        experienceType = .three
+                        text = ""
+
+                    case .three:
+                        break
                     }
                 }, isDisabled: false)
                     .focused($focused)


### PR DESCRIPTION
## 관련 이슈
Closes #81

## 문제
체험하기 1단계 '위험 문장 감지'에서 문장 입력 후 전송 버튼을 눌러도 무반응. `CustomTextField` enter가 `experienceType == .two`에서만 처리됐기 때문.

## 변경
enter 클로저를 단계별 `switch`로:
- **.one**: 입력 문장 전송(sendtext/isEnter 설정) 후 **2단계로 이동** ← 추가된 액션
- **.two**: 기존 알림 + 3단계 이동 유지
- **.three**: 무동작
- 빈 입력 가드 + 알림 문구 오타 수정

## 검증
- Presentation 스킴 빌드 통과 (exit 0)

## 참고
1단계 예시 칩(지금 돈 넣으면 등)은 현재 탭 시 바로 2단계로 점프합니다. 원하면 '칩=문장 채우기, 전송=단계 이동'으로 일관되게 바꿀 수 있어요(별도).

🤖 Generated with [Claude Code](https://claude.com/claude-code)