### PR TITLE
chore: #83 - Fastlane 도입 (빌드 검증 + TestFlight 업로드 자동화)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ xcuserdata
 # End of https://www.toptal.com/developers/gitignore/api/swift,swiftpackagemanager,xcode,swiftpm
 
 *.xcconfig
+# App Store Connect API 키 / 로컬 시크릿
+*.p8
+fastlane/.env

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,8 @@
+# 앱을 식별하는 기본 정보. fastlane이 "어떤 앱"을 다루는지 여기서 읽는다.
+
+app_identifier("com.jaesuneo.WatchOut")   # 앱 번들 ID
+team_id("NZJWJ35U9D")                      # Apple Developer 팀 ID (코드 서명용)
+
+# 아래는 TestFlight 업로드(3단계)에서 채울 예정 — 지금은 주석 처리.
+# apple_id("you@example.com")              # App Store Connect 로그인 계정
+# itc_team_id("...")                       # App Store Connect 팀 ID

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,18 @@
+# Fastfile: "lane"(작업 묶음)을 정의하는 곳.
+# 터미널에서  fastlane <레인이름>  으로 실행한다.
+
+default_platform(:ios)
+
+platform :ios do
+  desc "앱이 정상 빌드되는지 확인 (시뮬레이터·서명 없음, Apple 계정 불필요)"
+  lane :build_check do
+    build_app(
+      project: "WatchOut.xcodeproj",
+      scheme: "WatchOut",
+      destination: "generic/platform=iOS Simulator",
+      skip_archive: true,        # 아카이브 대신 build만 (검증용)
+      skip_codesigning: true,    # 시뮬레이터라 코드 서명 불필요
+      clean: false
+    )
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,16 @@
 
 default_platform(:ios)
 
+# App Store Connect API 키 객체 생성 (.env에서 값 읽음)
+def asc_api_key
+  app_store_connect_api_key(
+    key_id: ENV["ASC_KEY_ID"],
+    issuer_id: ENV["ASC_ISSUER_ID"],
+    key_filepath: File.expand_path(ENV["ASC_KEY_PATH"]),
+    duration: 1200
+  )
+end
+
 platform :ios do
   desc "앱이 정상 빌드되는지 확인 (시뮬레이터·서명 없음, Apple 계정 불필요)"
   lane :build_check do
@@ -10,9 +20,48 @@ platform :ios do
       project: "WatchOut.xcodeproj",
       scheme: "WatchOut",
       destination: "generic/platform=iOS Simulator",
-      skip_archive: true,        # 아카이브 대신 build만 (검증용)
-      skip_codesigning: true,    # 시뮬레이터라 코드 서명 불필요
+      skip_archive: true,
+      skip_codesigning: true,
       clean: false
+    )
+  end
+
+  desc "App Store Connect API 키 인증 확인 (업로드 없음)"
+  lane :asc_check do
+    api_key = asc_api_key
+    number = latest_testflight_build_number(
+      api_key: api_key,
+      app_identifier: "com.jaesuneo.WatchOut",
+      initial_build_number: 0
+    )
+    UI.success("✅ API 키 인증 성공! TestFlight 최신 빌드 번호: #{number}")
+  end
+
+  desc "TestFlight 업로드 (아카이브 빌드 → 업로드)"
+  lane :beta do
+    api_key = asc_api_key
+
+    # 최신 빌드 번호 +1 로 올려 충돌 방지
+    latest = latest_testflight_build_number(
+      api_key: api_key,
+      app_identifier: "com.jaesuneo.WatchOut",
+      initial_build_number: 0
+    )
+    increment_build_number(
+      xcodeproj: "WatchOut.xcodeproj",
+      build_number: latest + 1
+    )
+
+    build_app(
+      project: "WatchOut.xcodeproj",
+      scheme: "WatchOut",
+      export_method: "app-store",
+      xcargs: "-allowProvisioningUpdates"   # 자동 서명: 배포 프로파일 자동 생성/갱신
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      skip_waiting_for_build_processing: true   # 업로드만 하고 처리 대기는 생략
     )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,27 +41,26 @@ platform :ios do
   lane :beta do
     api_key = asc_api_key
 
-    # 최신 빌드 번호 +1 로 올려 충돌 방지
+    # 최신 빌드 번호 +1 (TestFlight 중복 빌드번호 방지)
     latest = latest_testflight_build_number(
       api_key: api_key,
       app_identifier: "com.jaesuneo.WatchOut",
       initial_build_number: 0
     )
-    increment_build_number(
-      xcodeproj: "WatchOut.xcodeproj",
-      build_number: latest + 1
-    )
+    new_build = latest + 1
+    UI.message("새 빌드 번호: #{new_build}")
 
     build_app(
       project: "WatchOut.xcodeproj",
       scheme: "WatchOut",
       export_method: "app-store",
-      xcargs: "-allowProvisioningUpdates"   # 자동 서명: 배포 프로파일 자동 생성/갱신
+      # 빌드 시점에 빌드번호 주입(앱+키보드 동일) + 자동 서명(배포 프로파일 자동 생성/갱신)
+      xcargs: "-allowProvisioningUpdates CURRENT_PROJECT_VERSION=#{new_build}"
     )
 
     upload_to_testflight(
       api_key: api_key,
-      skip_waiting_for_build_processing: true   # 업로드만 하고 처리 대기는 생략
+      skip_waiting_for_build_processing: true   # 업로드만, 처리 대기는 생략
     )
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,32 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## iOS
+
+### ios build_check
+
+```sh
+[bundle exec] fastlane ios build_check
+```
+
+앱이 정상 빌드되는지 확인 (시뮬레이터·서명 없음, Apple 계정 불필요)
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -23,6 +23,22 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 앱이 정상 빌드되는지 확인 (시뮬레이터·서명 없음, Apple 계정 불필요)
 
+### ios asc_check
+
+```sh
+[bundle exec] fastlane ios asc_check
+```
+
+App Store Connect API 키 인증 확인 (업로드 없음)
+
+### ios beta
+
+```sh
+[bundle exec] fastlane ios beta
+```
+
+TestFlight 업로드 (아카이브 빌드 → 업로드)
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
## 관련 이슈
Closes #83

## 내용
Fastlane으로 빌드/배포 자동화 도입.

### 추가된 lane
- `fastlane build_check` — 시뮬레이터 빌드 검증 (Apple 계정 불필요)
- `fastlane asc_check` — App Store Connect API 키 인증 확인 (업로드 없음)
- `fastlane beta` — 빌드번호 자동 증가 → 아카이브(app-store, 자동 서명) → TestFlight 업로드

### 구성
- `fastlane/Appfile` — 앱 식별 정보
- `fastlane/Fastfile` — lane 정의 + ASC API 키 헬퍼
- 시크릿(`fastlane/.env`, `*.p8`)은 .gitignore 처리 (repo 미포함)

## 검증
- `build_check` ✓ (Xcode 27)
- `asc_check` ✓ (API 인증 성공)
- `beta` ✓ (**TestFlight build 4 업로드 성공**)

## 셋업 메모 (다른 팀원용)
1. `brew install fastlane`
2. App Store Connect API `.p8` 키를 `~/.appstoreconnect/private_keys/`에 배치
3. `fastlane/.env` 생성: `ASC_KEY_ID` / `ASC_ISSUER_ID` / `ASC_KEY_PATH`
4. `fastlane beta` 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)