### PR TITLE
fix: #85 - 온보딩 가이드영상 미표시 및 권한 안내 깜빡임

### DIFF
--- a/Sources/Presentation/Auth/Onboarding/OnboardingContentViewModel.swift
+++ b/Sources/Presentation/Auth/Onboarding/OnboardingContentViewModel.swift
@@ -10,7 +10,8 @@ import Platform
 
 // MARK: - OnboardingContentViewModel
 final class OnboardingContentViewModel: ObservableObject {
-    @Published private var isKeyboardEnabled = false
+    // 첫 프레임부터 실제 키보드 활성 상태로 시작 → FirstView가 깜빡이고 사라지는 현상 방지.
+    @Published private var isKeyboardEnabled = KeyboardPermissionManager.isKeyboardEnabled()
     @Published private var isFirstSetting = false
 }
 

--- a/Sources/Presentation/Auth/Onboarding/OnboardingView.swift
+++ b/Sources/Presentation/Auth/Onboarding/OnboardingView.swift
@@ -29,16 +29,23 @@ private struct OnboardingContentView: View {
     fileprivate init(onboardingViewModel: OnboardingContentViewModel) {
         self.onboardingViewModel = onboardingViewModel
     }
+    
     fileprivate var body: some View {
+        isOnboardingView
+    }
+    
+    @ViewBuilder
+    var isOnboardingView: some View {
         ZStack {
             if !onboardingViewModel.getIsKeyboardEnabled() {
                 ZStack {
+                    VStack {
                     (DotLottieAnimation(
                         fileName: "guidevideo",
                         config: AnimationConfig(autoplay: true, loop: true)
                     ).view() as DotLottieView)
-
-                    VStack {
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                         Spacer()
                         OnboardingFirstView()
                     }


### PR DESCRIPTION
## 요약
온보딩 두 가지 버그 수정. Closes #85

## 변경
- **guidevideo 미표시**: `DotLottieView`에 `.scaledToFit().frame(maxWidth: .infinity, maxHeight: .infinity)` 추가. 프레임이 없어 레이아웃이 0으로 붕괴하던 문제 (정상 동작하는 loading/ready와 동일 패턴).
- **권한 안내 깜빡임**: `OnboardingContentViewModel.isKeyboardEnabled` 시작값을 `KeyboardPermissionManager.isKeyboardEnabled()` 실제 상태로 초기화. 항상 `false`로 시작해 FirstView가 한 프레임 떴다 사라지던 문제.

## 테스트
- 키보드 미설정: 가이드영상 화면 표시 + 영상 재생 ✅
- 키보드 설정됨: 깜빡임 없이 SecondView 바로 ✅
- 가이드 → 설정에서 키보드 추가 → 복귀: SecondView 자동 전환 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 온보딩 화면이 처음 표시될 때 실제 키보드 활성 상태를 바로 반영하도록 개선했습니다.
  * 앱이 다시 활성화되면 키보드 상태를 재확인해 화면 표시가 더 정확해졌습니다.
  * 키보드 사용 가능 여부에 따라 안내 애니메이션과 화면 구성이 안정적으로 전환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->