### PR TITLE
feat: #87 - 위험/경고 감지 시 그룹원 자동 푸시 + 카운트 서버 반영

### DIFF
--- a/Sources/KeyboardKit/Service/GroupNotificationService.swift
+++ b/Sources/KeyboardKit/Service/GroupNotificationService.swift
@@ -1,0 +1,57 @@
+//
+//  GroupNotificationService.swift
+//  WatchOutkeyboard
+//
+//  위험/경고 감지 시 서버에 카운트를 업데이트하고, 서버가 그룹원에게 자동 푸시를 보낸다.
+//  - PUT /api/notifications/danger-count   { user_id, danger_count }
+//  - PUT /api/notifications/warning-count  { user_id, warning_count }
+//  키보드 익스텐션(Full Access)에서 호출. user_id는 App Group(SharedUserDefaults)에서 읽는다.
+//
+
+import Foundation
+
+public struct GroupNotificationService {
+
+    public static let shared = GroupNotificationService()
+
+    private let baseURL = "https://wiheome.ajb.kr/api"
+
+    private init() {}
+
+    /// 위험(danger) 카운트 업데이트 + 그룹 자동 푸시.
+    public func reportDangerCount(userId: String, count: Int) {
+        send(path: "/notifications/danger-count", body: ["user_id": userId, "danger_count": count])
+    }
+
+    /// 경고(caution) 카운트 업데이트 + 그룹 자동 푸시.
+    public func reportWarningCount(userId: String, count: Int) {
+        send(path: "/notifications/warning-count", body: ["user_id": userId, "warning_count": count])
+    }
+
+    private func send(path: String, body: [String: Any]) {
+        // user_id가 비면 서버가 식별 불가 → 호출하지 않음.
+        if let uid = body["user_id"] as? String, uid.isEmpty {
+            print("[GroupNotify] user_id 비어있음 → 전송 생략")
+            return
+        }
+        guard let url = URL(string: baseURL + path),
+              let data = try? JSONSerialization.data(withJSONObject: body) else {
+            print("[GroupNotify] 요청 생성 실패: \(path)")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+
+        URLSession.shared.dataTask(with: request) { _, response, error in
+            if let error = error {
+                print("[GroupNotify] 전송 실패 \(path): \(error.localizedDescription)")
+                return
+            }
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            print("[GroupNotify] \(path) → \(code)")
+        }.resume()
+    }
+}

--- a/Sources/KeyboardKit/Session/FraudDetectionSession.swift
+++ b/Sources/KeyboardKit/Session/FraudDetectionSession.swift
@@ -66,12 +66,22 @@ public final class FraudDetectionSession: ObservableObject {
             }
             if SharedUserDefaults.isTutorial == false {
                 SharedUserDefaults.riskLevel2Count += 1
+                // 서버 경고 카운트 업데이트 + 그룹원 자동 푸시
+                GroupNotificationService.shared.reportWarningCount(
+                    userId: SharedUserDefaults.userID,
+                    count: SharedUserDefaults.riskLevel2Count
+                )
             }
 
         case .danger:
             dangerCount += 1
             if SharedUserDefaults.isTutorial == false {
                 SharedUserDefaults.riskLevel3Count += 1
+                // 서버 위험 카운트 업데이트 + 그룹원 자동 푸시
+                GroupNotificationService.shared.reportDangerCount(
+                    userId: SharedUserDefaults.userID,
+                    count: SharedUserDefaults.riskLevel3Count
+                )
             }
             if dangerCount % 3 == 0, SharedUserDefaults.isDangerNotification {
                 NotificationManager.instance.scheduleNotification(


### PR DESCRIPTION
## 요약
키보드가 위험/경고를 감지하면 서버에 카운트를 업데이트하고 서버가 그룹원에게 자동 푸시를 보내도록 연결. Closes #87

## 변경
- `GroupNotificationService` (신규): 키보드 익스텐션에서 호출
  - `PUT /api/notifications/danger-count`  `{ user_id, danger_count }`
  - `PUT /api/notifications/warning-count` `{ user_id, warning_count }`
  - `user_id`는 App Group(`SharedUserDefaults.userID`), 카운트는 누적값
- `FraudDetectionSession.handle()` caution/danger 분기에서 호출 (튜토리얼 제외)

## 효과
- 그룹 화면 `danger_count` 갱신(기존 미반영) + 그룹원 자동 푸시 — 한 경로로 해결

## 비고
- 실제 danger 발화 트리거는 서버 WS `check_fraud` 응답에 의존. 현재 해당 WS 무응답(백엔드) 이슈가 별도로 있어, 그게 해결되거나 온디바이스 탐지로 전환되면 동작. 본 PR은 감지 이후(카운트/푸시) 배선 완성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 위험 및 경고 상태가 발생하면 그룹에 관련 카운트를 자동으로 보고하는 기능이 추가되었습니다.
  * 사용자별 경고/위험 수치를 외부 서비스로 전송할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->