### PR TITLE
feat: #89 - 디바이스 토큰 서버 등록 보강 (그룹 푸시 누락 방지)

### DIFF
--- a/Sources/Data/DTO/Request/AuthRequest.swift
+++ b/Sources/Data/DTO/Request/AuthRequest.swift
@@ -18,8 +18,24 @@ public struct KakaoLoginRequest: Codable {
 
 public struct KakaoDeleteRequest: Codable {
     public let userId: String
-    
+
     public enum CodingKeys: String, CodingKey {
         case userId = "user_id"
+    }
+}
+
+/// POST /auth/device-token — 디바이스 토큰 등록/갱신 (user_id 기반)
+public struct DeviceTokenRequest: Codable {
+    public let userId: String
+    public let deviceToken: String
+
+    public init(userId: String, deviceToken: String) {
+        self.userId = userId
+        self.deviceToken = deviceToken
+    }
+
+    public enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case deviceToken = "device_token"
     }
 }

--- a/WatchOut/App/AppDelegate.swift
+++ b/WatchOut/App/AppDelegate.swift
@@ -48,7 +48,32 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         print("✅ Device Token: \(token)")
         TokenManager.shared.saveDeviceToken(token)
-        
+        registerDeviceTokenToServer(token)
+    }
+
+    /// 수신한 디바이스 토큰을 서버에 등록한다.
+    /// 로그인 바디 전송만으로는 토큰 도착 타이밍(비동기)·회전을 놓쳐 그룹 푸시가 누락되므로,
+    /// 토큰을 받는 즉시(로그인 상태면) 서버에 갱신해 항상 최신값을 보유하게 한다.
+    private func registerDeviceTokenToServer(_ token: String) {
+        let userId = SharedUserDefaults.userID
+        guard !userId.isEmpty else {
+            print("ℹ️ user_id 없음(로그인 전) → 토큰은 로그인 시 전송됨")
+            return
+        }
+        Task {
+            do {
+                try await APIClient.default.request(
+                    try Endpoint(
+                        path: "auth/device-token",
+                        method: .post,
+                        json: DeviceTokenRequest(userId: userId, deviceToken: token)
+                    )
+                )
+                print("✅ 디바이스 토큰 서버 등록 완료")
+            } catch {
+                print("❌ 디바이스 토큰 서버 등록 실패: \(error)")
+            }
+        }
     }
     
     


### PR DESCRIPTION
## 요약
그룹 푸시가 실제로 도달하도록, 디바이스 토큰을 서버에 안정적으로 등록. Closes #89

## 문제
- 토큰은 **로그인 바디로만** 전송 → APNs 비동기 도착보다 로그인이 빠르면 `"시뮬레이터"`(쓰레기값) 저장
- 토큰 수신 콜백은 Keychain 저장만, 서버 미전송 → 로그인 후 도착/회전 시 서버가 옛 토큰 보유 → 푸시 누락

## 변경
- `DeviceTokenRequest` DTO (`{ user_id, device_token }`)
- `AppDelegate.didRegisterForRemoteNotificationsWithDeviceToken` 에서 수신 즉시 `POST /api/auth/device-token` (로그인 상태일 때)

## 효과
- 로그인 전 도착 → 로그인 바디가 실제 토큰 전송
- 로그인 후 도착/회전 → 본 POST가 갱신 (기존 "시뮬레이터" 오염도 덮어씀)

🤖 Generated with [Claude Code](https://claude.com/claude-code)